### PR TITLE
개인 팀 노트북을 .gitignore에 추가하여 레포지토리에 커밋되는 것을 방지합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ Thumbs.db
 
 # Uploads directory (if contains user data)
 uploads/
-"AIM_Evaluation_v2 서현.ipynb"
-"AIM_Evaluation_v2 유비.ipynb"
-"AIM_Evaluation_v2 재민.ipynb"
-"AIM_Evaluation_v2 재석.ipynb"
+AIM_Evaluation_v2 서현.ipynb
+AIM_Evaluation_v2 유비.ipynb
+AIM_Evaluation_v2 재민.ipynb
+AIM_Evaluation_v2 재석.ipynb


### PR DESCRIPTION
이제 다음 파일들은 무시됩니다:
- AIM_Evaluation_v2 서현.ipynb
- AIM_Evaluation_v2 유비.ipynb
- AIM_Evaluation_v2 재민.ipynb
- AIM_Evaluation_v2 재석.ipynb

이 파일들은 git 캐시에서도 제거되었습니다.